### PR TITLE
Allow non-root users to run plugin

### DIFF
--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -7,5 +7,6 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
 
 RUN mkdir -p /tmp
 RUN chmod 777 /tmp
+
 ADD release/linux/amd64/drone-gcs /bin/
 ENTRYPOINT ["/bin/drone-gcs"]

--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -1,10 +1,15 @@
+FROM alpine:3.12 as alpine
+RUN apk add -U --no-cache ca-certificates
+
 FROM alpine:3.12
+ENV GODEBUG netdns=go
 
 LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.name="Drone GCS" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
+COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 RUN mkdir -p /tmp
 RUN chmod 777 /tmp
 

--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -2,16 +2,14 @@ FROM alpine:3.12 as alpine
 RUN apk add -U --no-cache ca-certificates
 
 FROM alpine:3.12
-ENV GODEBUG netdns=go
 
 LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.name="Drone GCS" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
+ENV GODEBUG netdns=go
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-RUN mkdir -p /tmp
-RUN chmod 777 /tmp
 
 ADD release/linux/amd64/drone-gcs /bin/
 ENTRYPOINT ["/bin/drone-gcs"]

--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -1,9 +1,11 @@
-FROM plugins/base:multiarch
+FROM alpine:3.12
 
 LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.name="Drone GCS" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
+RUN mkdir -p /tmp
+RUN chmod 777 /tmp
 ADD release/linux/amd64/drone-gcs /bin/
 ENTRYPOINT ["/bin/drone-gcs"]

--- a/docker/Dockerfile.linux.arm
+++ b/docker/Dockerfile.linux.arm
@@ -1,11 +1,17 @@
+FROM arm32v6/alpine:3.12 as alpine
+RUN apk add -U --no-cache ca-certificates
+
 FROM arm32v6/alpine:3.12
+ENV GODEBUG netdns=go
 
 LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.name="Drone GCS" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
+COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 RUN mkdir -p /tmp
 RUN chmod 777 /tmp
+
 ADD release/linux/arm/drone-gcs /bin/
 ENTRYPOINT ["/bin/drone-gcs"]

--- a/docker/Dockerfile.linux.arm
+++ b/docker/Dockerfile.linux.arm
@@ -2,16 +2,14 @@ FROM arm32v6/alpine:3.12 as alpine
 RUN apk add -U --no-cache ca-certificates
 
 FROM arm32v6/alpine:3.12
-ENV GODEBUG netdns=go
 
 LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.name="Drone GCS" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
+ENV GODEBUG netdns=go
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-RUN mkdir -p /tmp
-RUN chmod 777 /tmp
 
 ADD release/linux/arm/drone-gcs /bin/
 ENTRYPOINT ["/bin/drone-gcs"]

--- a/docker/Dockerfile.linux.arm
+++ b/docker/Dockerfile.linux.arm
@@ -1,9 +1,11 @@
-FROM plugins/base:multiarch
+FROM arm32v6/alpine:3.12
 
 LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.name="Drone GCS" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
+RUN mkdir -p /tmp
+RUN chmod 777 /tmp
 ADD release/linux/arm/drone-gcs /bin/
 ENTRYPOINT ["/bin/drone-gcs"]

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -1,9 +1,11 @@
-FROM plugins/base:multiarch
+FROM arm64v8/alpine:3.12
 
 LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.name="Drone GCS" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
+RUN mkdir -p /tmp
+RUN chmod 777 /tmp
 ADD release/linux/arm64/drone-gcs /bin/
 ENTRYPOINT ["/bin/drone-gcs"]

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -2,16 +2,14 @@ FROM arm64v8/alpine:3.12 as alpine
 RUN apk add -U --no-cache ca-certificates
 
 FROM arm64v8/alpine:3.12
-ENV GODEBUG netdns=go
 
 LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.name="Drone GCS" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
+ENV GODEBUG netdns=go
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-RUN mkdir -p /tmp
-RUN chmod 777 /tmp
 
 ADD release/linux/arm64/drone-gcs /bin/
 ENTRYPOINT ["/bin/drone-gcs"]

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -1,11 +1,17 @@
+FROM arm64v8/alpine:3.12 as alpine
+RUN apk add -U --no-cache ca-certificates
+
 FROM arm64v8/alpine:3.12
+ENV GODEBUG netdns=go
 
 LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.name="Drone GCS" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
+COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 RUN mkdir -p /tmp
 RUN chmod 777 /tmp
+
 ADD release/linux/arm64/drone-gcs /bin/
 ENTRYPOINT ["/bin/drone-gcs"]


### PR DESCRIPTION
When json-key is used for authentication, key is first stored in a temporary directory. In case of non-root user, file creation in temporary directory is failing. 

**Fix**: Create tmp directory in dockerfile and provide permission so that any user can write to it. Multi-arch image used earlier does not have /bin/sh installed to run any command in dockerfile. Also, multi-stage build is not preserving the permissions. Hence, using alpine as base images. These base images are same as the ones used in drone/git plugin.