### PR TITLE
Add support for bucket object --folder option.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ _test
 *.[568vq]
 [568vq].out
 
+# IDE settings
+.idea/
+
 *.cgo1.go
 *.cgo2.c
 _cgo_defun.c

--- a/go.mod
+++ b/go.mod
@@ -4,16 +4,19 @@ go 1.15
 
 require (
 	cloud.google.com/go v0.21.0
-	github.com/golang/protobuf v1.0.0
-	github.com/googleapis/gax-go v2.0.0+incompatible
+	github.com/golang/glog v0.0.0-20210429001901-424d2337a529 // indirect
+	github.com/golang/protobuf v1.0.0 // indirect
+	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/googleapis/gax-go v2.0.0+incompatible // indirect
 	github.com/pkg/errors v0.8.0
 	github.com/urfave/cli v1.20.0
-	go.opencensus.io v0.8.0
+	go.opencensus.io v0.8.0 // indirect
 	golang.org/x/net v0.0.0-20180415214307-500e7a4f953d
 	golang.org/x/oauth2 v0.0.0-20180402223937-921ae394b943
-	golang.org/x/text v0.3.0
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	golang.org/x/text v0.3.0 // indirect
 	google.golang.org/api v0.0.0-20180413000347-fca24fcb4112
-	google.golang.org/appengine v1.0.0
-	google.golang.org/genproto v0.0.0-20180413175816-7fd901a49ba6
-	google.golang.org/grpc v1.11.3
+	google.golang.org/appengine v1.0.0 // indirect
+	google.golang.org/genproto v0.0.0-20180413175816-7fd901a49ba6 // indirect
+	google.golang.org/grpc v1.11.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
 cloud.google.com/go v0.21.0 h1:083TLU7hqb1CzKeMhzDsCTP4uXkBGr6nnWuaHdVNBCI=
 cloud.google.com/go v0.21.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/golang/glog v0.0.0-20210429001901-424d2337a529 h1:2voWjNECnrZRbfwXxHB1/j8wa6xdKn85B5NzgVL/pTU=
+github.com/golang/glog v0.0.0-20210429001901-424d2337a529/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/protobuf v1.0.0 h1:lsek0oXi8iFE9L+EXARyHIjU5rlWIhhTkjDz3vHhWWQ=
 github.com/golang/protobuf v1.0.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/googleapis/gax-go v2.0.0+incompatible h1:j0GKcs05QVmm7yesiZq2+9cxHkNK9YM6zKx4D2qucQU=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
@@ -14,10 +18,15 @@ golang.org/x/net v0.0.0-20180415214307-500e7a4f953d h1:YbPBOQdSo5fFDiZgBDcltE4Xj
 golang.org/x/net v0.0.0-20180415214307-500e7a4f953d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/oauth2 v0.0.0-20180402223937-921ae394b943 h1:hE+k6oRG1aru6/y8A0HI01Zqp65EZcUcKToTkbPsFFM=
 golang.org/x/oauth2 v0.0.0-20180402223937-921ae394b943/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.0.0-20180413000347-fca24fcb4112 h1:ZwIBv243B9oUEb2HVMTQs//+WVhsL5hsUoCAu1ydobs=
 google.golang.org/api v0.0.0-20180413000347-fca24fcb4112/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
+google.golang.org/appengine v1.0.0 h1:dN4LljjBKVChsv0XCSI+zbyzdqrkEwX5LQFUMRSGqOc=
 google.golang.org/appengine v1.0.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/genproto v0.0.0-20180413175816-7fd901a49ba6 h1:VrRtqEIrO5wUzNwL/A2WTNUtDuAtvb3KPK3OrUriLqI=
 google.golang.org/genproto v0.0.0-20180413175816-7fd901a49ba6/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/main.go
+++ b/main.go
@@ -52,8 +52,13 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:   "target",
-			Usage:  "destination to copy files to, including bucket name",
+			Usage:  "destination bucket to copy files to, can include folder path",
 			EnvVar: "PLUGIN_TARGET",
+		},
+		cli.StringFlag{
+			Name:   "folder",
+			Usage:  "destination folder path to copy files to, will be appended to target",
+			EnvVar: "PLUGIN_FOLDER",
 		},
 		cli.StringSliceFlag{
 			Name:   "gzip",
@@ -84,6 +89,7 @@ func run(c *cli.Context) error {
 			ACL:          c.StringSlice("acl"),
 			Source:       c.String("source"),
 			Target:       c.String("target"),
+			Folder:       c.String("folder"),
 			Ignore:       c.String("ignore"),
 			Gzip:         c.StringSlice("gzip"),
 			CacheControl: c.String("cache-control"),


### PR DESCRIPTION
This PR adds support for specifying a bucket object folder via a new `--folder` option. This update is meant to be backwards compatible with the current `--target` option and will append a path to any object path discovered from the initial `--target` option value.

The motivation for this change is that I have a drone workflow wherein the `bucket` value is retrieved from a drone secret (using `from_secret`). I need to dynamically create the object name folder path during CI. By separating the bucket value from the folder path it makes this workflow possible.

Both the README and tests have been updated in support of this PR.