### PR TITLE
golang image upgrade to 1.18

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ platform:
 steps:
 - name: vet
   pull: always
-  image: golang:1.17.8
+  image: golang:1.18
   commands:
   - go vet ./...
   environment:
@@ -20,7 +20,7 @@ steps:
 
 - name: test
   pull: always
-  image: golang:1.17.8
+  image: golang:1.18
   commands:
   - go test -cover ./...
   environment:
@@ -50,7 +50,7 @@ platform:
 steps:
 - name: build-push
   pull: always
-  image: golang:1.17.8
+  image: golang:1.18
   commands:
   - "go build -v -ldflags \"-X main.version=${DRONE_COMMIT_SHA:0:8}\" -a -tags netgo -o release/linux/amd64/drone-gcs"
   environment:
@@ -63,7 +63,7 @@ steps:
 
 - name: build-tag
   pull: always
-  image: golang:1.17.8
+  image: golang:1.18
   commands:
   - "go build -v -ldflags \"-X main.version=${DRONE_TAG##v}\" -a -tags netgo -o release/linux/amd64/drone-gcs"
   environment:
@@ -75,7 +75,7 @@ steps:
 
 - name: executable
   pull: always
-  image: golang:1.17.8
+  image: golang:1.18
   commands:
   - ./release/linux/amd64/drone-gcs --help
 
@@ -134,7 +134,7 @@ platform:
 steps:
 - name: build-push
   pull: always
-  image: golang:1.17.8
+  image: golang:1.18
   commands:
   - "go build -v -ldflags \"-X main.version=${DRONE_COMMIT_SHA:0:8}\" -a -tags netgo -o release/linux/arm64/drone-gcs"
   environment:
@@ -147,7 +147,7 @@ steps:
 
 - name: build-tag
   pull: always
-  image: golang:1.17.8
+  image: golang:1.18
   commands:
   - "go build -v -ldflags \"-X main.version=${DRONE_TAG##v}\" -a -tags netgo -o release/linux/arm64/drone-gcs"
   environment:
@@ -159,7 +159,7 @@ steps:
 
 - name: executable
   pull: always
-  image: golang:1.17.8
+  image: golang:1.18
   commands:
   - ./release/linux/arm64/drone-gcs --help
 
@@ -218,7 +218,7 @@ platform:
 steps:
 - name: build-push
   pull: always
-  image: golang:1.17.8
+  image: golang:1.18
   commands:
   - "go build -v -ldflags \"-X main.version=${DRONE_COMMIT_SHA:0:8}\" -a -tags netgo -o release/linux/arm/drone-gcs"
   environment:
@@ -231,7 +231,7 @@ steps:
 
 - name: build-tag
   pull: always
-  image: golang:1.17.8
+  image: golang:1.18
   commands:
   - "go build -v -ldflags \"-X main.version=${DRONE_TAG##v}\" -a -tags netgo -o release/linux/arm/drone-gcs"
   environment:
@@ -243,7 +243,7 @@ steps:
 
 - name: executable
   pull: always
-  image: golang:1.17.8
+  image: golang:1.18
   commands:
   - ./release/linux/arm/drone-gcs --help
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/drone-plugins/drone-gcs
 
-go 1.17
+go 1.18
 
 require (
 	cloud.google.com/go/storage v1.18.2


### PR DESCRIPTION
The automation suite for drone-gcs is passing successfully with the new updated images.

Reason for image update:
1. Security Reference Ticket - https://harness.atlassian.net/browse/SECAPP-258
2. To meet federal requirements for storing harness images.