### PR TITLE
Use the ADC as a default fallback

### DIFF
--- a/main.go
+++ b/main.go
@@ -131,7 +131,10 @@ func run(c *cli.Context) error {
 			return err
 		}
 	} else {
-		return errors.New("Either one of token or json key must be specified")
+		client, err = gcsClientApplicationDefaultCredentials()
+		if err != nil {
+			return err
+		}
 	}
 
 	return plugin.Exec(client)
@@ -150,6 +153,7 @@ func gcsClientWithToken(token string) (*storage.Client, error) {
 	}
 	return client, nil
 }
+
 func gcsClientWithJSONKey(jsonKey string, credFile *os.File) (*storage.Client, error) {
 	if _, err := credFile.Write([]byte(jsonKey)); err != nil {
 		return nil, errors.Wrap(err, "failed to write gcs credentials to file")
@@ -160,6 +164,15 @@ func gcsClientWithJSONKey(jsonKey string, credFile *os.File) (*storage.Client, e
 
 	ctx := context.Background()
 	client, err := storage.NewClient(ctx, option.WithCredentialsFile(credFile.Name()))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to initialize storage")
+	}
+	return client, nil
+}
+
+func gcsClientApplicationDefaultCredentials() (*storage.Client, error) {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize storage")
 	}


### PR DESCRIPTION
# What

* Change default authentication method to use the ADC

# Why

Google recommends against directly specifying which method of authentication to use for its client libraries, and instead recommends you use the [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials). This lets the client library use all available authentication methods, and is more universally compatible.

For example, this lets one use Workload Identity on Drone agents, where we don't have an access token or contents of a credential JSON file, and instead authentication is provided via the metadata API.