### PR TITLE
feat: [CI-18070]: Add glob pattern support for sourcePath parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,61 @@ docker run --rm \
   plugins/gcs
 ```
 
+## Glob Pattern Support
+
+The plugin now supports glob patterns for the `PLUGIN_SOURCE` parameter, enabling flexible file selection:
+
+### Basic Glob Patterns
+
+* `*` - matches any sequence of characters (except path separators)
+* `?` - matches any single character  
+* `[]` - matches any character within brackets
+* `**` - recursive directory matching
+
+### Examples
+
+```console
+# Upload all JavaScript files from any subdirectory
+PLUGIN_SOURCE="src/**/*.js"
+
+# Upload specific file types from multiple directories
+PLUGIN_SOURCE="dist/*.html,assets/*.css,build/*.js"
+
+# Upload all files from specific directories
+PLUGIN_SOURCE="public/**,static/**"
+
+# Mixed patterns - directories and globs
+PLUGIN_SOURCE="./dist,./assets/*.png,docs/**/*.md"
+```
+
+### Multiple Pattern Support
+
+You can specify multiple patterns separated by commas:
+
+```console
+docker run --rm \
+  -e PLUGIN_SOURCE="dist/*.html,assets/**/*.{css,js},docs/*.md" \
+  -e PLUGIN_TARGET="bucket/website/" \
+  -e PLUGIN_IGNORE="**/*.tmp,**/*.log" \
+  plugins/gcs
+```
+
+### Enhanced Ignore Patterns
+
+The `PLUGIN_IGNORE` parameter also supports multiple patterns:
+
+```console
+# Ignore multiple file types and directories
+PLUGIN_IGNORE="*.log,*.tmp,node_modules/**,**/.git/**"
+```
+
+### Backward Compatibility
+
+All existing functionality remains unchanged:
+- Single directory paths work exactly as before
+- Existing ignore patterns continue to function
+- No configuration changes required for current deployments
+
 * For download
 ```console
 docker run --rm \

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -531,9 +531,18 @@ func TestRootLevelGlobPatterns(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Change to temp directory to simulate real scenario
-	oldDir, _ := os.Getwd()
-	defer os.Chdir(oldDir)
-	os.Chdir(tmpDir)
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldDir); err != nil {
+			t.Errorf("failed to restore directory: %v", err)
+		}
+	}()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change directory: %v", err)
+	}
 
 	// Create test files in current directory
 	writeFile(t, ".", "op.txt", []byte("test content"))
@@ -589,9 +598,18 @@ func TestProductionScenarioReproduction(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Change to temp directory
-	oldDir, _ := os.Getwd()
-	defer os.Chdir(oldDir)
-	os.Chdir(tmpDir)
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldDir); err != nil {
+			t.Errorf("failed to restore directory: %v", err)
+		}
+	}()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change directory: %v", err)
+	}
 
 	// Create test file
 	writeFile(t, ".", "op.txt", []byte("test content"))
@@ -653,9 +671,18 @@ func TestEndToEndRootLevelGlob(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Change to temp directory (simulate /harness)
-	oldDir, _ := os.Getwd()
-	defer os.Chdir(oldDir)
-	os.Chdir(tmpDir)
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldDir); err != nil {
+			t.Errorf("failed to restore directory: %v", err)
+		}
+	}()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change directory: %v", err)
+	}
 
 	// Create test files directly in current directory
 	writeFile(t, ".", "op.txt", []byte("test content"))
@@ -728,9 +755,18 @@ func TestHarnessProductionScenario(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Change to temp directory to simulate /harness working directory
-	oldDir, _ := os.Getwd()
-	defer os.Chdir(oldDir)
-	os.Chdir(tmpDir)
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldDir); err != nil {
+			t.Errorf("failed to restore directory: %v", err)
+		}
+	}()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change directory: %v", err)
+	}
 
 	// Create the exact file from your error: op.txt
 	writeFile(t, ".", "op.txt", []byte("production test content"))


### PR DESCRIPTION
## Summary
Adds robust glob pattern support to PLUGIN_SOURCE and PLUGIN_IGNORE for flexible file selection and filtering.

- Glob patterns: dist/*.js, src/**/*.css, assets/[abc].png
- Multiple patterns: dist/*.html,assets/*.css,docs/*.md
- Enhanced ignore: *.log,*.tmp,node_modules/**
- Recursive matching: ** for deep directory traversal
- Individual files: path/specific-file.txt

#### Example usage:
```yaml
- name: upload-to-gcs
  image: plugins/gcs
  settings:
    source: dist/*.zip       # Upload all ZIP files in dist directory
    target: my-bucket/builds
    ignore: "*.tmp"          # Exclude temporary files
```
This change improves flexibility when specifying which files to upload while maintaining all existing functionality.

## Testing
- Confirming backward compatibility
- Manually tested various glob patterns including `*.txt`, `**/*.go`, and nested patterns
[link](https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/opaci/pipelines/restorekeypatternk1/executions/P8vEvO0ITWir8WrgaYUEBw/pipeline?storeType=INLINE)