### PR TITLE
feat: [CI-18070]: improved ignore file handling for glob support

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -119,15 +119,15 @@ func (p *Plugin) Exec(client *storage.Client) error {
 
 	// create a list of files to upload using glob pattern expansion
 	p.printf("expanding source patterns: %s", p.Config.Source)
-	
+
 	// Expand glob patterns into actual source paths
 	expandedSources, err := p.expandGlobPatterns(p.Config.Source)
 	if err != nil {
 		return errors.Wrap(err, "failed to expand source patterns")
 	}
-	
+
 	p.printf("found %d source paths after expansion", len(expandedSources))
-	
+
 	// Walk all expanded sources to collect files with their source directories
 	fileToSourceMap, err := p.walkGlobFilesWithSources(expandedSources)
 	if err != nil {
@@ -474,7 +474,7 @@ func (p *Plugin) walkGlobFilesWithSources(sources []string) (map[string]string, 
 
 		// Determine the base directory for relative path calculation
 		var baseDir string
-		
+
 		// Ensure source is absolute first
 		absSource := source
 		if !filepath.IsAbs(source) {
@@ -484,7 +484,7 @@ func (p *Plugin) walkGlobFilesWithSources(sources []string) (map[string]string, 
 				return nil, fmt.Errorf("failed to get absolute path for '%s': %w", source, err)
 			}
 		}
-		
+
 		if info, err := os.Stat(absSource); err == nil && !info.IsDir() {
 			// If source is a file (from glob expansion), use its directory as base
 			baseDir = filepath.Dir(absSource)
@@ -535,7 +535,9 @@ func (p *Plugin) walkSingleSource(sourcePath string) ([]string, error) {
 
 	// If it's a file, add it directly (after checking ignore pattern)
 	if !info.IsDir() {
-		if p.shouldIgnoreFile(sourcePath, sourcePath) {
+		// For files, use the directory as the source path for ignore pattern matching
+		sourceDir := filepath.Dir(sourcePath)
+		if p.shouldIgnoreFile(sourceDir, sourcePath) {
 			return items, nil // Return empty list if file should be ignored
 		}
 		return []string{sourcePath}, nil


### PR DESCRIPTION
Changes:
- When the source is an individual file (expanded from a glob), use its directory as the base for `shouldIgnoreFile`
- Prevents comparing the ignore pattern against ".", so files meant to be skipped are now correctly excluded.

Testing: [[LINK](https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/opaci/pipelines/CI18070dronegcsglobsupport/executions/Fi5ZmQ-VRKyVZjxNGahSBg/pipeline?stage=oX3Yag-rT_-705IQWPM9BA&step=A1v1PDE3STi3sdZEEwLN6w&childStage=&stageExecId=)] - confirmed on both linux and windows 

<img width="1593" height="686" alt="Screenshot 2025-07-21 at 7 05 32 PM" src="https://github.com/user-attachments/assets/7c534687-f6c9-4f4c-82af-a345cb6f9c45" />
