### PR TITLE
fix: [CI-22411]: fix-missing-objectName-error-for-uploadGCS-empty-target-value

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -164,10 +164,13 @@ func (p *Plugin) Exec(client *storage.Client) error {
 				return
 			}
 
-			var dst string
-			if singleFile && !p.isDirTarget(p.Config.Target) {
-				dst = p.Config.Target
-			} else {
+		var dst string
+		if singleFile && !p.isDirTarget(p.Config.Target) {
+			dst = p.Config.Target
+			if dst == "" {
+				dst = rel
+			}
+		} else {
 				dst = path.Join(p.Config.Target, rel)
 			}
 

--- a/plugin.go
+++ b/plugin.go
@@ -164,13 +164,13 @@ func (p *Plugin) Exec(client *storage.Client) error {
 				return
 			}
 
-		var dst string
-		if singleFile && !p.isDirTarget(p.Config.Target) {
-			dst = p.Config.Target
-			if dst == "" {
-				dst = rel
-			}
-		} else {
+			var dst string
+			if singleFile && !p.isDirTarget(p.Config.Target) {
+				dst = p.Config.Target
+				if dst == "" {
+					dst = rel
+				}
+			} else {
 				dst = path.Join(p.Config.Target, rel)
 			}
 

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -1164,6 +1164,61 @@ func TestAllProductionScenarios(t *testing.T) {
 	}
 }
 
+// TestRunEmptyTargetSingleFile verifies that when Target is empty and source is a single
+// file, the file is uploaded using its original filename (not an empty object name).
+// This is a fix for: googleapi: Error 400: No object name, required
+func TestRunEmptyTargetSingleFile(t *testing.T) {
+	wdir, err := os.MkdirTemp("", "drone-gcs-empty-target-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(wdir)
+
+	writeFile(t, wdir, "artifact.txt", []byte("content"))
+
+	var uploadedName string
+
+	rt := &fakeTransport{func(r *http.Request) (*http.Response, error) {
+		uploadedName = r.URL.Query().Get("name")
+		return &http.Response{
+			Body:       io.NopCloser(strings.NewReader(`{"name": "artifact.txt"}`)),
+			Proto:      "HTTP/1.0",
+			ProtoMajor: 1,
+			ProtoMinor: 0,
+			StatusCode: http.StatusOK,
+		}, nil
+	}}
+
+	hc := &http.Client{Transport: rt}
+	client, _ := storage.NewClient(context.Background(), option.WithHTTPClient(hc))
+
+	p := &Plugin{
+		Config: Config{
+			Source: filepath.Join(wdir, "artifact.txt"),
+			Target: "my-bucket",
+		},
+		printf: t.Logf,
+		fatalf: t.Fatalf,
+	}
+	p.bucket = client.Bucket("my-bucket")
+
+	// Simulate what Exec() does: split target to get bucket name and path
+	tgt := strings.SplitN(p.Config.Target, "/", 2)
+	if len(tgt) == 1 {
+		p.Config.Target = ""
+	} else {
+		p.Config.Target = tgt[1]
+	}
+
+	if err := p.Exec(client); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+
+	if uploadedName != "artifact.txt" {
+		t.Errorf("uploaded object name = %q, want %q", uploadedName, "artifact.txt")
+	}
+}
+
 // TestBackwardCompatibility tests that existing functionality still works
 func TestBackwardCompatibility(t *testing.T) {
 	// Create temporary directory structure


### PR DESCRIPTION
fix: [CI-22411]: Fix Error 400 when uploading a single file with no target path

## Summary
- When target was left empty, the plugin tried to upload with an empty object name, 
  causing "googleapi: Error 400: No object name, required" [Check-Error-Repro-Here-v0](https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/default_project/pipelines/uploadGCS/deployments/4RI-yRtIT6S55uvrZN9MOg/pipeline?storeType=INLINE) | [Error-Repro-v1](https://unifiedpipeline.harness.io/ng/account/MGY3MmJmM2ItNTY5Ny00Yj/all/orgs/default/projects/CI_Sanity_Integ_Test/pipelines/uploadtogcp/deployments/nD1BVx2mTbuFPbpAiU1hRg/pipeline?storeType=INLINE)
- Fixed by falling back to the original filename when no target path is given, 
  so the file uploads to the bucket root instead of failing
- Bug existed in both v0 and v1; added unit test TestRunEmptyTargetSingleFile

## Test plan
- [x] Single file with no target uploads as gs://bucket/filename ✓
- [x] Single file with target uploads to correct path ✓
- [x] Directory upload with and without target ✓
- [x] All existing plugin tests pass ✓

[Sample-Test-Execution-v0](https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/default_project/pipelines/uploadGCS/deployments/oTTPoBbKSoero8inhX0DhA/pipeline?storeType=INLINE)
[Sample-Test-Execution-v1](https://unifiedpipeline.harness.io/ng/account/MGY3MmJmM2ItNTY5Ny00Yj/all/orgs/default/projects/CI_Sanity_Integ_Test/pipelines/uploadtogcp/deployments/YfaV54xxQUaahhSEszr14g/pipeline?storeType=INLINE)

[CI-22411]: https://harness.atlassian.net/browse/CI-22411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ