### PR TITLE
feat: [CI-23717]: windows 2025 support

### DIFF
--- a/docker/Dockerfile.windows.ltsc2025
+++ b/docker/Dockerfile.windows.ltsc2025
@@ -1,0 +1,18 @@
+# escape=`
+
+# ---------------------------------------------------------------------------
+# drone-gcs for Windows Server 2025 (LTSC 2025)
+# ---------------------------------------------------------------------------
+
+FROM plugins/base:windows-ltsc2025-amd64
+USER ContainerAdministrator
+
+ENV GODEBUG=netdns=go
+
+LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
+  org.label-schema.name="Drone GCS" `
+  org.label-schema.vendor="Drone.IO Community" `
+  org.label-schema.schema-version="1.0"
+
+ADD release/windows/amd64/drone-gcs.exe C:/drone-gcs.exe
+ENTRYPOINT [ "C:\\drone-gcs.exe" ]

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -29,3 +29,9 @@ manifests:
       architecture: amd64
       os: windows
       version: ltsc2022
+  -
+    image: plugins/gcs:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}windows-ltsc2025-amd64
+    platform:
+      architecture: amd64
+      os: windows
+      version: ltsc2025


### PR DESCRIPTION
This pull request adds support for Windows Server 2025 (LTSC 2025) to the Drone GCS plugin, enabling builds and deployments targeting this new Windows version. The main changes include the addition of a new Dockerfile and an updated manifest to publish the corresponding image.

**Windows Server 2025 (LTSC 2025) support:**

* Added `docker/Dockerfile.windows.ltsc2025` to build the Drone GCS plugin for Windows Server 2025, including base image selection, environment variables, labels, and entrypoint configuration.
* Updated `docker/manifest.tmpl` to include a manifest entry for the new `windows-ltsc2025-amd64` image variant, ensuring it is published alongside other supported platforms.
<img width="1634" height="325" alt="Screenshot 2026-07-14 at 1 00 03 PM" src="https://github.com/user-attachments/assets/3696223c-ce62-42da-a5d3-a17512ac8cb5" />
<img width="1410" height="741" alt="Screenshot 2026-07-14 at 1 00 14 PM" src="https://github.com/user-attachments/assets/6cd12d19-e918-40a2-862d-54e5bc77b2af" />
